### PR TITLE
remove meetup attendee photos

### DIFF
--- a/src/components/Meetup.astro
+++ b/src/components/Meetup.astro
@@ -9,7 +9,6 @@ const {
   location,
   eventUrl,
   photo,
-  memberPhotos,
   rsvpCount,
   rsvpsOpen,
 } = Astro.props;
@@ -41,19 +40,6 @@ const {
   </div>
   <div class="row">
     <div class="attendees">
-      {
-        memberPhotos.length > 0 &&
-          memberPhotos.map((photo) => (
-            <Image
-              class="memberPhoto"
-              src={photo}
-              alt="Member photo"
-              width="32"
-              height="32"
-              loading="lazy"
-            />
-          ))
-      }
       <span>{rsvpCount || 0} attendees</span>
     </div>
     {
@@ -117,16 +103,7 @@ ${formatDateTime(dateTime)}`;
     display: flex;
     flex-direction: row;
     align-items: center;
-    padding: 8px;
     gap: 8px;
-  }
-
-  .memberPhoto {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 0.5px solid #000;
-    margin-left: -16px;
   }
 
   .photo {


### PR DESCRIPTION
For web performance reasons removing the attendee photos. These photos are from Meetup.com and they are not compressed so they use a lot of data to load. 